### PR TITLE
Only set state when media has changed on client mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "hoist-non-react-statics": "^1.2.0",
     "matchmedia": "^0.1.2",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "shallowequal": "^1.0.2"
   }
 }

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import matchMedia from 'matchmedia';
 import PropTypes from 'prop-types';
+import shallowequal from 'shallowequal';
 
 const defaultQueries = {
   mobile: 'screen and (max-width: 623px)',
@@ -49,7 +50,11 @@ class MediaQueryProvider extends React.Component {
   // check for matches on client mount
   clientMatch = () => {
     const media = this.queryMedia(this.props.queries, {});
-    this.setState({ media });
+
+    // no need to set state when it hasnt changed
+    if (!shallowequal(media, this.media)) {
+      this.setState({ media });
+    }
   }
 
   render() {

--- a/test/integration.js
+++ b/test/integration.js
@@ -32,7 +32,7 @@ describe('Integration Tests', () => {
     stub.restore();
   });
 
-  it('should render not render mobile view after client / server mismatch', () => {
+  it('should not render mobile view after client / server mismatch', () => {
     const values = {
       width: 300,
       type: 'screen',

--- a/test/media-query-provider.js
+++ b/test/media-query-provider.js
@@ -68,7 +68,7 @@ describe('<MediaQueryProvider />', () => {
     });
   });
 
-  describe('when mobile matches', () => {
+  context('when mobile matches', () => {
     let mobileComponent;
 
     before(() => {
@@ -120,7 +120,7 @@ describe('<MediaQueryProvider />', () => {
     stub.restore();
   });
 
-  describe('when rendering server-side', () => {
+  context('when rendering server-side', () => {
     it('should render', () => {
       expect(() => {
         const html = ReactDOMServer.renderToString(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3003,6 +3003,10 @@ setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
+shallowequal@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
+
 shelljs@^0.7.5:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"


### PR DESCRIPTION
Should make a decent performance improvement for when `MediaQueryProvider` wraps many child components of which do not have shallow `shouldComponentUpdate` checks

The extra lib `shallowequal` is less than 1kb so size isnt a concern