### PR TITLE
Added support for React.Fragment

### DIFF
--- a/dist/media-query-provider.js
+++ b/dist/media-query-provider.js
@@ -103,7 +103,11 @@ var MediaQueryProvider = function (_React$Component) {
   }, {
     key: 'render',
     value: function render() {
-      return _react2.default.createElement(
+      return _react2.default.Fragment ? _react2.default.createElement(
+        _react2.default.Fragment,
+        null,
+        this.props.children
+      ) : _react2.default.createElement(
         'div',
         null,
         this.props.children

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -58,10 +58,10 @@ class MediaQueryProvider extends React.Component {
   }
 
   render() {
-    return (
-      <div>
-        { this.props.children }
-      </div>
+    return React.Fragment ? (
+      <React.Fragment>{this.props.children}</React.Fragment>
+    ) : (
+      <div>{this.props.children}</div>
     );
   }
 }

--- a/test/media-query-provider.js
+++ b/test/media-query-provider.js
@@ -131,4 +131,29 @@ describe('<MediaQueryProvider />', () => {
       }).to.not.throw();
     });
   });
+
+  if (React.Fragment) {
+    context('when React.Fragment is available', () => {
+      it('should render a div', () => {
+        const component = mount(
+          <MediaQueryProvider>
+            <p>Test123</p>
+          </MediaQueryProvider>,
+        );
+        expect(component.find('div').is('div')).to.eql(false);
+        expect(component.find('p').is('p')).to.eql(true);
+      });
+    });
+  } else {
+    context('when React.Fragment is not available', () => {
+      it('should render a div', () => {
+        const component = mount(
+          <MediaQueryProvider>
+            <p>Test123</p>
+          </MediaQueryProvider>,
+        );
+        expect(component.find('div').is('div')).to.eql(true);
+      });
+    });
+  }
 });

--- a/test/media-query-provider.js
+++ b/test/media-query-provider.js
@@ -132,28 +132,50 @@ describe('<MediaQueryProvider />', () => {
     });
   });
 
-  if (React.Fragment) {
-    context('when React.Fragment is available', () => {
-      it('should render a div', () => {
-        const component = mount(
-          <MediaQueryProvider>
-            <p>Test123</p>
-          </MediaQueryProvider>,
-        );
-        expect(component.find('div').is('div')).to.eql(false);
-        expect(component.find('p').is('p')).to.eql(true);
+  context('when React.Fragment is available', () => {
+    before(() => {
+      Object.defineProperty(React, 'Fragment', {
+        configurable: true,
+        value: React.createClass({
+          render: function() {
+            return React.createElement(
+              'span',
+              {className: 'wrapper'},
+              Array.isArray(this.props.children) ? 
+                this.props.children.map((el) => <span>{el}</span>) :
+                this.props.children
+            );
+          }
+        }),
       });
     });
-  } else {
-    context('when React.Fragment is not available', () => {
-      it('should render a div', () => {
-        const component = mount(
-          <MediaQueryProvider>
-            <p>Test123</p>
-          </MediaQueryProvider>,
-        );
-        expect(component.find('div').is('div')).to.eql(true);
-      });
+
+    after(() => {
+      Reflect.deleteProperty(React, 'Fragment');
     });
-  }
+
+    it('should use React.Fragment component', () => {
+      const fragmentChildren = [
+        <p>Test123</p>,
+        <p>Test123</p>,
+      ];
+      const component = mount(
+        <MediaQueryProvider>
+          <fragmentChildren />
+        </MediaQueryProvider>,
+      );
+      expect(component.find('span').is('span')).to.eql(true);
+    });
+  });
+
+  context('when React.Fragment is not available', () => {
+    it('should render a div', () => {
+      const component = mount(
+        <MediaQueryProvider>
+          <p>Test123</p>
+        </MediaQueryProvider>,
+      );
+      expect(component.find('div').is('div')).to.eql(true);
+    });
+  });
 });


### PR DESCRIPTION
Hi, I added some code so that this will not wrap the child component in a div if React.Fragment is available. This keeps it from altering the DOM structure that the users will expect. Please take a look.

I did add tests for both cases, but it will only test for the version that's a requirement for this package itself, so until it is updated to require React 16, it'll just run the test that doesn't require React.Fragment. 