### PR TITLE
Fixed mobile Safari issue causing media query event listener to fail.

### DIFF
--- a/dist/media-query-provider.js
+++ b/dist/media-query-provider.js
@@ -86,7 +86,7 @@ var MediaQueryProvider = function (_React$Component) {
 
         // this is so we can keep a reference to the MediaQueryList for removing the listener
         // and knowing the queryName in `mediaQueryListener`
-        _this2.mediaQueryListInstanceMap.set(mediaQueryListInstance, queryName);
+        _this2.mediaQueryListInstanceMap.set(mediaQueryListInstance.media, { query: mediaQueryListInstance, queryName: queryName });
 
         acc[queryName] = mediaQueryListInstance.matches;
         return acc;
@@ -101,17 +101,17 @@ var MediaQueryProvider = function (_React$Component) {
     value: function componentWillUnmount() {
       var _this3 = this;
 
-      this.mediaQueryListInstanceMap.forEach(function (_, mediaQueryList) {
-        mediaQueryList.removeListener(_this3.mediaQueryListener);
+      this.mediaQueryListInstanceMap.forEach(function (mediaQueryList) {
+        return mediaQueryList.query.removeListener(_this3.mediaQueryListener);
       });
     }
   }, {
     key: 'mediaQueryListener',
     value: function mediaQueryListener(_ref) {
       var matches = _ref.matches,
-          target = _ref.target;
+          media = _ref.media;
 
-      var queryName = this.mediaQueryListInstanceMap.get(target);
+      var queryName = this.mediaQueryListInstanceMap.get(media).queryName;
       var newMedia = _extends({}, this.state.media, _defineProperty({}, queryName, matches));
 
       if (!(0, _shallowequal2.default)(newMedia, this.state.media)) {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.8.2",
     "jsdom": "^11.0.0",
-    "match-media-mock": "^0.1.0",
     "mocha": "^5.2.0",
     "react": "^16.3.2",
     "react-addons-test-utils": "^15.1.0",

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -44,7 +44,7 @@ class MediaQueryProvider extends React.Component {
 
       // this is so we can keep a reference to the MediaQueryList for removing the listener
       // and knowing the queryName in `mediaQueryListener`
-      this.mediaQueryListInstanceMap.set(mediaQueryListInstance, queryName);
+      this.mediaQueryListInstanceMap.set(mediaQueryListInstance.media, { query: mediaQueryListInstance, queryName });
 
       acc[queryName] = mediaQueryListInstance.matches;
       return acc;
@@ -57,12 +57,12 @@ class MediaQueryProvider extends React.Component {
 
   componentWillUnmount() {
     this.mediaQueryListInstanceMap.forEach((_, mediaQueryList) => {
-      mediaQueryList.removeListener(this.mediaQueryListener);
+      mediaQueryList.query.removeListener(this.mediaQueryListener);
     });
   }
 
-  mediaQueryListener({ matches, target }) {
-    const queryName = this.mediaQueryListInstanceMap.get(target);
+  mediaQueryListener({ matches, media }) {
+    const queryName = this.mediaQueryListInstanceMap.get(media).queryName;
     const newMedia = {
       ...this.state.media,
       [queryName]: matches,

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -61,7 +61,7 @@ class MediaQueryProvider extends React.Component {
   }
 
   mediaQueryListener({ matches, media }) {
-    const queryName = this.mediaQueryListInstanceMap.get(media).queryName;
+    const { queryName } = this.mediaQueryListInstanceMap.get(media);
     const newMedia = {
       ...this.state.media,
       [queryName]: matches,

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -56,9 +56,8 @@ class MediaQueryProvider extends React.Component {
   }
 
   componentWillUnmount() {
-    this.mediaQueryListInstanceMap.forEach((_, mediaQueryList) => {
-      mediaQueryList.query.removeListener(this.mediaQueryListener);
-    });
+    this.mediaQueryListInstanceMap.forEach(mediaQueryList =>
+      mediaQueryList.query.removeListener(this.mediaQueryListener));
   }
 
   mediaQueryListener({ matches, media }) {

--- a/test/media-query-provider.js
+++ b/test/media-query-provider.js
@@ -3,7 +3,7 @@ import ReactDOMServer from 'react-dom/server';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
-import matchMediaMock from 'match-media-mock';
+import cssMediaQuery from 'css-mediaquery';
 import MediaQueryProvider from '../src/media-query-provider';
 
 describe('<MediaQueryProvider />', () => {
@@ -16,14 +16,17 @@ describe('<MediaQueryProvider />', () => {
       value: () => {},
     });
 
-    const matchMediaMockInstance = matchMediaMock.create();
-    matchMediaMockInstance.setConfig({ type: 'screen', width: 1200 });
-    window.matchMedia = matchMediaMockInstance;
+    const getMatchMediaMock = (config) => {
+      return (media) => {
+        const matches = cssMediaQuery.match(media, config);
+        return { matches, media, addListener: () => {}, removeListener: () => {} };
+      };
+    };
+    window.matchMedia = getMatchMediaMock({ type: 'screen', width: 1200 });
   });
 
   after(() => {
     Reflect.deleteProperty(global, 'HTMLElement');
-    delete window.matchMedia;
   });
 
   it('should render app', () => {

--- a/test/media-query-provider.js
+++ b/test/media-query-provider.js
@@ -43,6 +43,7 @@ describe('<MediaQueryProvider />', () => {
 
   after(() => {
     Reflect.deleteProperty(global, 'HTMLElement');
+    delete window.matchMedia;
   });
 
   it('should render app', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,12 +634,6 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
In Safari on iOS, the media prop on the wrapped component isn't updating when the mobile device rotates.

The reason is that the listener is depending on the received event to be an object with a `target` property with the media query object in it, but that property isn't provided by mobile Safari.

Instead, it provides a much simpler object (`matches` and `media` are present - those are guaranteed by the spec)