### PR TITLE
Moved getMatchMediaMock() to another file and shared it with the integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.8.2",
     "jsdom": "^11.0.0",
-    "match-media-mock": "^0.1.0",
     "mocha": "^5.2.0",
     "react": "^16.3.2",
     "react-addons-test-utils": "^15.1.0",

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render, mount } from 'enzyme';
-import matchMediaMock from 'match-media-mock';
+import getMatchMediaMock from './utils/get-match-media-mock';
 import withMedia from '../src/with-media';
 import TestComponent from './utils/test-component';
 import MediaQueryProvider from '../src/media-query-provider';
@@ -9,9 +9,8 @@ import MediaQueryProvider from '../src/media-query-provider';
 describe('Integration Tests', () => {
   before(() => {
     // mock browser media match to have large screen
-    const matchMediaMockInstance = matchMediaMock.create();
-    matchMediaMockInstance.setConfig({ type: 'screen', width: 1200 });
-    window.matchMedia = matchMediaMockInstance;
+    const matchMediaMock = getMatchMediaMock({ type: 'screen', width: 1200 });
+    window.matchMedia = matchMediaMock.matchMedia;
   });
 
   after(() => {

--- a/test/media-query-provider.js
+++ b/test/media-query-provider.js
@@ -3,26 +3,8 @@ import ReactDOMServer from 'react-dom/server';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
-import cssMediaQuery from 'css-mediaquery';
+import getMatchMediaMock from './utils/get-match-media-mock';
 import MediaQueryProvider from '../src/media-query-provider';
-
-const getMatchMediaMock = (config) => {
-  const listeners = {};
-  return {
-    update: (newConfig) => Object.keys(listeners).forEach((media) => {
-      listeners[media].forEach((listener) => listener({ matches: cssMediaQuery.match(media, newConfig), media }));
-    }),
-    matchMedia: (media) => {
-      listeners[media] = [];
-      return {
-        matches: cssMediaQuery.match(media, config),
-        media,
-        addListener: (listener) => { listeners[media].push(listener); },
-        removeListener: () => {},
-      };
-    },
-  };
-};
 
 describe('<MediaQueryProvider />', () => {
   let component;

--- a/test/utils/get-match-media-mock.js
+++ b/test/utils/get-match-media-mock.js
@@ -1,0 +1,19 @@
+import cssMediaQuery from 'css-mediaquery';
+
+export default (config) => {
+  const listeners = {};
+  return {
+    update: (newConfig) => Object.keys(listeners).forEach((media) => {
+      listeners[media].forEach((listener) => listener({ matches: cssMediaQuery.match(media, newConfig), media }));
+    }),
+    matchMedia: (media) => {
+      listeners[media] = [];
+      return {
+        matches: cssMediaQuery.match(media, config),
+        media,
+        addListener: (listener) => { listeners[media].push(listener); },
+        removeListener: () => {},
+      };
+    },
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,10 +1436,6 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-exenv@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -2159,10 +2155,6 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^3.9.3:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
 lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
@@ -2183,14 +2175,6 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-match-media-mock@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/match-media-mock/-/match-media-mock-0.1.0.tgz#19f3d4302140a96d347a4416a29ac5a034f4af9a"
-  dependencies:
-    css-mediaquery "^0.1.2"
-    exenv "^1.2.0"
-    lodash "^3.9.3"
 
 math-random@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Moved `getMatchMediaMock()` to a utils file so the integration tests can use it too

I stupidly forgot to physically remove `match-media-mock` from `node_modules` so I didn't realise it was still being used by the integration tests.
