### PR TITLE
Prevent multiple renders when two breakpoints change

### DIFF
--- a/dist/media-query-provider.js
+++ b/dist/media-query-provider.js
@@ -44,8 +44,6 @@ var MediaQueryProvider = function (_React$Component) {
 
     var _this = _possibleConstructorReturn(this, (MediaQueryProvider.__proto__ || Object.getPrototypeOf(MediaQueryProvider)).call(this, props));
 
-    _this.media = {};
-
     var media = Object.keys(_this.props.queries).reduce(function (acc, queryName) {
       var query = _this.props.queries[queryName];
 

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -10,8 +10,6 @@ class MediaQueryProvider extends React.Component {
   constructor(props) {
     super(props);
 
-    this.media = {};
-
     const media = Object.keys(this.props.queries).reduce((acc, queryName) => {
       const query = this.props.queries[queryName];
 

--- a/test/media-query-provider.js
+++ b/test/media-query-provider.js
@@ -138,7 +138,7 @@ describe('<MediaQueryProvider />', () => {
     expect(spy.callCount).to.equal(4);
   });
 
-  it('handles matchMedia listener events and updates the context', () => {
+  it('handles matchMedia listener events and updates the context', (done) => {
     const testComponent = mount(
       <MediaQueryProvider>
         <p>Test123</p>
@@ -146,11 +146,16 @@ describe('<MediaQueryProvider />', () => {
     );
 
     const { media: mediaBefore } = testComponent.instance().getChildContext();
-    matchMediaMock.update({ type: 'screen', width: 600 });
-    const { media: mediaAfter } = testComponent.instance().getChildContext();
-
     expect(mediaBefore).to.eql({ desktop: true, largeDesktop: false, mobile: false, tablet: false });
-    expect(mediaAfter).to.eql({ desktop: false, largeDesktop: false, mobile: true, tablet: false });
+
+    matchMediaMock.update({ type: 'screen', width: 600 });
+    // Set timeout because we don't longer expect this to fire immediately due to
+    // logic that prevents multiple renders from happening when breakpoints change.
+    setTimeout(() => {
+      const { media: mediaAfter } = testComponent.instance().getChildContext();
+      expect(mediaAfter).to.eql({ desktop: false, largeDesktop: false, mobile: true, tablet: false });
+      done();
+    }, 0);
   });
 
 


### PR DESCRIPTION
This PR fixes a minor bug - when you resize the window, two state changes happen - one for each media query listener that has changed.

Resizing narrower - e.g. going from tablet to mobile will have two state changes and renders: e.g.
1. `{ mobile: true, tablet: true, desktop: false }`
2. `{ moible: true, tablet: false, desktop: false }`

And resizing wider - e.g. from mobile to tablet will also have two state changes and renders: e.g.
1. `{ mobile: false, tablet: false, desktop: false }`
2. `{ mobile: false, tablet: true, desktop: false }`

If you're conditionally rendering some components based on something like
`if (media.mobile || media.tablet) { ... } else { ... }`
then the whole mobile/tablet component tree will be unmounted and remounted again during this transition.

For me, that bug resulted in a video element that was playing loosing state and being unloaded when trying to switch to landscape and portrait mode (which meant trying to use fullScreen failed).


Overall, the changes in this PR are
1. Debounce the call to setState by using setTimeout with 0ms - so that it only fires once when multiple mediaQueryListener change events fire.
2. Use an instance variable to keep track of values - because `this.state.media` is unreliable in the callback now that we're debouncing the state changes.