### PR TITLE
Change default value of 'values' prop

### DIFF
--- a/dist/media-query-provider.js
+++ b/dist/media-query-provider.js
@@ -105,6 +105,7 @@ var MediaQueryProvider = function (_React$Component) {
 
       // need to rerender with correct media if it didnt match up with initial
       if (!(0, _shallowequal2.default)(media, this.state.media)) {
+        this.currentMediaState = media;
         this.setState({ media: media }); // eslint-disable-line react/no-did-mount-set-state
       }
     }

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -118,7 +118,7 @@ MediaQueryProvider.defaultProps = {
     desktop: 'screen and (min-width: 1021px) and (max-width: 1440px)',
     largeDesktop: 'screen and (min-width: 1441px)',
   },
-  values: {},
+  values: undefined,
 };
 
 export { MediaContext };

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -66,6 +66,7 @@ class MediaQueryProvider extends React.Component {
 
     // need to rerender with correct media if it didnt match up with initial
     if (!shallowequal(media, this.state.media)) {
+      this.currentMediaState = media;
       this.setState({ media }); // eslint-disable-line react/no-did-mount-set-state
     }
   }
@@ -118,7 +119,7 @@ MediaQueryProvider.defaultProps = {
     desktop: 'screen and (min-width: 1021px) and (max-width: 1440px)',
     largeDesktop: 'screen and (min-width: 1441px)',
   },
-  values: undefined,
+  values: {},
 };
 
 export { MediaContext };


### PR DESCRIPTION
If a consumer doesn't pass `values` the component should match queries using `window.matchMedia` on initialisation, if available. However, because the default value of `values` prop is `{}`, which is truthy, the component tries to match against an empty object instead.

Conditional check is here: https://github.com/xanido/react-media-query-hoc/blob/b86628/src/media-query-provider.js#L21