### PR TITLE
feat: expose MediaContext to be used with useContext hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,8 @@ This is a HOC to provide media match props to your component.
 ```javascript
 import { withMedia } from 'react-media-query-hoc';
 
-const MyComponent = ({ media, ...props}) => (
-  if(media.tablet || media.mobile) {
-    ..
+const MyComponent = ({ media, ...props}) => {
+  if (media.tablet || media.mobile) {
     return (
       <div>
         Mobile and Tablet View
@@ -94,14 +93,45 @@ const MyComponent = ({ media, ...props}) => (
     <div>
       Other View
     </div>
-  )
-);
+  );
+};
 
 export const BaseMyComponent = MyComponent;
 export default withMedia(MyComponent);
 ```
 
 Components wrapped by `withMedia()` won't work with React's usual `ref` mechanism, because the ref supplied will be for `withMedia` rather than the wrapped component. Therefore a prop, `wrappedRef` provides the same function. Note: this means the wrapped component can not be a [stateless function](https://github.com/facebook/react/issues/10831).
+
+### `MediaContext`
+This is the React Context exported and ready to be used with React `useContext` hook. It has a default value of `{}`, present when the component that consumes the context is not wrapped with `MediaQueryProvider`.
+
+```javascript
+import { MediaContext } from 'react-media-query-hoc';
+import { useContext } from 'react';
+
+const MyComponent = (props) => {
+  const media = useContext(MediaContext);
+
+  if(media.tablet || media.mobile) {
+    return (
+      <div>
+        Mobile and Tablet View
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      Other View
+    </div>
+  );
+};
+
+export default MyComponent;
+
+// default value
+ReactDOM.render(<MyComponent />);     // Renders 'Other View';
+```
 
 ### Server Side Rendering
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.withMedia = exports.MediaQueryProvider = undefined;
+exports.withMedia = exports.MediaQueryProvider = exports.MediaContext = undefined;
 
 var _mediaQueryProvider = require('./media-query-provider');
 
@@ -15,5 +15,6 @@ var _withMedia2 = _interopRequireDefault(_withMedia);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+exports.MediaContext = _mediaQueryProvider.MediaContext;
 exports.MediaQueryProvider = _mediaQueryProvider2.default;
 exports.withMedia = _withMedia2.default;

--- a/dist/media-query-provider.js
+++ b/dist/media-query-provider.js
@@ -41,7 +41,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var hasMatchMedia = typeof window !== 'undefined' && typeof window.matchMedia === 'function';
 
-var MediaContext = _react2.default.createContext();
+var MediaContext = _react2.default.createContext({});
 
 var MediaQueryProvider = function (_React$Component) {
   _inherits(MediaQueryProvider, _React$Component);

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
-import MediaQueryProvider from './media-query-provider';
+import MediaQueryProvider, { MediaContext } from './media-query-provider';
 import withMedia from './with-media';
 
 export {
+  MediaContext,
   MediaQueryProvider,
   withMedia,
 };

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -9,7 +9,7 @@ import { debounce } from './utils';
 const hasMatchMedia =
   typeof window !== 'undefined' && typeof window.matchMedia === 'function';
 
-const MediaContext = React.createContext();
+const MediaContext = React.createContext({});
 
 class MediaQueryProvider extends React.Component {
   constructor(props) {

--- a/test/media-context.js
+++ b/test/media-context.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import MediaQueryProvider, { MediaContext } from '../src/media-query-provider';
+import getMatchMediaMock from './utils/get-match-media-mock';
+
+
+function TestComponentWithContext() {
+  return (
+    <MediaContext.Consumer>
+      {
+        media => (<span><p className="test-component">{media.mobile ? 'Mobile!' : 'Other!'}</p></span>)
+      }
+    </MediaContext.Consumer>);
+}
+
+describe('<MediaContext />', () => {
+  before(() => {
+    // mock browser media match to have local screen
+    const matchMediaMock = getMatchMediaMock({ type: 'screen', width: 300 });
+    window.matchMedia = matchMediaMock.matchMedia;
+  });
+
+  after(() => {
+    delete window.matchMedia;
+  });
+
+  it('provides current media context', () => {
+    const component =
+      mount(
+        <MediaQueryProvider>
+          <TestComponentWithContext />
+        </MediaQueryProvider>,
+      );
+    expect(component.find('.test-component').text()).to.equal('Mobile!');
+  });
+
+  it('provides an empty object if wrapper <MediaQueryProvider /> is not up in the tree', () => {
+    const component =
+      mount(
+        <TestComponentWithContext />,
+      );
+    expect(component.find('.test-component').text()).to.equal('Other!');
+  });
+});


### PR DESCRIPTION
Exports `MediaContext` along with HOC and Provider (so it can be used with `useContext`).
Also sets a default value of `{}` for the context.