### PR TITLE
Fix a bug in the media query provider

### DIFF
--- a/dist/media-query-provider.js
+++ b/dist/media-query-provider.js
@@ -105,6 +105,7 @@ var MediaQueryProvider = function (_React$Component) {
 
       // need to rerender with correct media if it didnt match up with initial
       if (!(0, _shallowequal2.default)(media, this.state.media)) {
+        this.currentMediaState = media;
         this.setState({ media: media }); // eslint-disable-line react/no-did-mount-set-state
       }
     }

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -66,6 +66,7 @@ class MediaQueryProvider extends React.Component {
 
     // need to rerender with correct media if it didnt match up with initial
     if (!shallowequal(media, this.state.media)) {
+      this.currentMediaState = media
       this.setState({ media }); // eslint-disable-line react/no-did-mount-set-state
     }
   }

--- a/src/media-query-provider.js
+++ b/src/media-query-provider.js
@@ -66,7 +66,7 @@ class MediaQueryProvider extends React.Component {
 
     // need to rerender with correct media if it didnt match up with initial
     if (!shallowequal(media, this.state.media)) {
-      this.currentMediaState = media
+      this.currentMediaState = media;
       this.setState({ media }); // eslint-disable-line react/no-did-mount-set-state
     }
   }


### PR DESCRIPTION
This patch prevents the primary media state (this.state.media) and
the auxiliary media state (this.currentMediaState) from going out
of sync (which causes an obscure bug) in componentDidMount.

Probably the best fix would be to get rid of the redundant state completely, but that would require a bit more involved refactoring.